### PR TITLE
Error boundaries for NFL, NBA, Soccer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,6 @@ function App() {
         <Message />
 
         <div className="card-columns">
-          {/* TODO add ErrorBoundary */}
           {widgetsVisible.NFL && <NFL />}
           {widgetsVisible.NBA && <NBA />}
           {widgetsVisible.Soccer && <Soccer />}

--- a/src/ErrorCard.tsx
+++ b/src/ErrorCard.tsx
@@ -1,0 +1,22 @@
+import React, { FC } from 'react';
+import { Card } from './simpleui';
+
+const ErrorCard: FC<{ name: string }> = ({ name }) => {
+  return (
+    <Card
+      title={
+        <span>
+          <span className="font-weight-bold">{name}</span>
+        </span>
+      }
+    >
+      <div className="p-4">
+        <span>Something went wrong :( </span>
+        <br />
+        <span>Try refreshing the page.</span>
+      </div>
+    </Card>
+  );
+};
+
+export default ErrorCard;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,13 +1,18 @@
 import React, { ErrorInfo, ReactNode } from 'react';
 
-export class ErrorBoundary extends React.Component {
+type Props = {
+  message?: ReactNode;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+};
+
+export class ErrorBoundary extends React.Component<Props> {
   state = {
     hasError: false
   };
 
   message?: ReactNode;
 
-  constructor(props: { message?: ReactNode }) {
+  constructor(props: Props) {
     super(props);
 
     this.message = props.message;
@@ -19,7 +24,7 @@ export class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.log(error, errorInfo);
+    this.props.onError?.(error, errorInfo);
   }
 
   render() {

--- a/src/components/NBA.tsx
+++ b/src/components/NBA.tsx
@@ -4,6 +4,9 @@ import getNBAData from '../SportsDataAccessors/nba/getNBAData';
 import { NBADataI, NBAGameI } from '../SportsDataAccessors/nba/NbaDatatypes';
 import createScheduleReducer from './createScheduleReducer';
 import GameTableNba from './GameTableNba';
+import ErrorCard from '../ErrorCard';
+import { ErrorBoundary } from './ErrorBoundary';
+import { widgetOnError } from './widgetCatchError';
 
 const initFromCache = (init: NBADataI): NBADataI => {
   try {
@@ -19,7 +22,7 @@ const initFromCache = (init: NBADataI): NBADataI => {
   }
 };
 
-const NBA = () => {
+const NBASchedule = () => {
   useEffect(() => {
     getNBAData().then(data =>
       nbaScheduleDispatch({ type: 'SET_NEW', newState: data })
@@ -53,5 +56,14 @@ const NBA = () => {
     </Card>
   );
 };
+
+const NBA = () => (
+  <ErrorBoundary
+    onError={widgetOnError('NBA', 'NBA_DATA_v1')}
+    message={<ErrorCard name="NBA" />}
+  >
+    <NBASchedule />
+  </ErrorBoundary>
+);
 
 export default NBA;

--- a/src/components/NBA.tsx
+++ b/src/components/NBA.tsx
@@ -4,6 +4,7 @@ import getNBAData from '../SportsDataAccessors/nba/getNBAData';
 import { NBADataI, NBAGameI } from '../SportsDataAccessors/nba/NbaDatatypes';
 import createScheduleReducer from './createScheduleReducer';
 import GameTableNba from './GameTableNba';
+import { useThrowForErrorBoundary } from '../hooks/useErrorBoundary';
 import ErrorCard from '../ErrorCard';
 import { ErrorBoundary } from './ErrorBoundary';
 import { widgetOnError } from './widgetCatchError';
@@ -23,11 +24,13 @@ const initFromCache = (init: NBADataI): NBADataI => {
 };
 
 const NBASchedule = () => {
+  const [throwFcError] = useThrowForErrorBoundary();
+
   useEffect(() => {
-    getNBAData().then(data =>
-      nbaScheduleDispatch({ type: 'SET_NEW', newState: data })
-    );
-  }, []);
+    getNBAData()
+      .then(data => nbaScheduleDispatch({ type: 'SET_NEW', newState: data }))
+      .catch(e => throwFcError(e));
+  }, [throwFcError]);
 
   const [nbaSchedule, nbaScheduleDispatch] = useReducer(
     createScheduleReducer<NBADataI>('NBA_DATA_v1'),

--- a/src/components/NFL.tsx
+++ b/src/components/NFL.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Button, Progress, Spinner } from 'reactstrap';
+import ErrorCard from '../ErrorCard';
 import useVisibilityHandlers from '../hooks/useVisibilityHandlers';
 import { Card } from '../simpleui';
 import getNFLData from '../SportsDataAccessors/nfl/getNflData';
 import { NFLSchedule } from '../SportsDataAccessors/types';
+import { ErrorBoundary } from './ErrorBoundary';
 import GameTable from './GameTable';
+import { widgetOnError } from './widgetCatchError';
 
 function carryOverHiddenGames(
   schedule: NFLSchedule,
@@ -23,9 +26,9 @@ function carryOverHiddenGames(
   return schedule;
 }
 
-export default function NFL() {
-  const LOCAL_STORAGE_KEY = 'nfl-schedule-data';
+const LOCAL_STORAGE_KEY = 'nfl-schedule-data';
 
+function NFLScheduleCard() {
   const [schedule, setSchedule] = useState<NFLSchedule>({
     displayDate: '',
     games: []
@@ -128,3 +131,14 @@ export default function NFL() {
     </Card>
   );
 }
+
+const NFL = () => (
+  <ErrorBoundary
+    onError={widgetOnError('NFL', LOCAL_STORAGE_KEY)}
+    message={<ErrorCard name="NFL" />}
+  >
+    <NFLScheduleCard />
+  </ErrorBoundary>
+);
+
+export default NFL;

--- a/src/components/NFL.tsx
+++ b/src/components/NFL.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Button, Progress, Spinner } from 'reactstrap';
 import ErrorCard from '../ErrorCard';
+import { useThrowForErrorBoundary } from '../hooks/useErrorBoundary';
 import useVisibilityHandlers from '../hooks/useVisibilityHandlers';
 import { Card } from '../simpleui';
 import getNFLData from '../SportsDataAccessors/nfl/getNflData';
@@ -33,6 +34,8 @@ function NFLScheduleCard() {
     displayDate: '',
     games: []
   });
+
+  const [throwFcError] = useThrowForErrorBoundary();
 
   // const [isLoading, setIsLoading] = useState<boolean>(false);
   const isLoading = false;
@@ -66,7 +69,7 @@ function NFLScheduleCard() {
       localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(schedule));
     } catch (e) {
       // setIsLoading(false);
-      console.error(e);
+      throwFcError(e);
     }
   };
 

--- a/src/components/Soccer.tsx
+++ b/src/components/Soccer.tsx
@@ -6,6 +6,9 @@ import getChampionsLeagueData, {
 } from '../SportsDataAccessors/soccer/getChampionsLeagueData';
 import createScheduleReducer from './createScheduleReducer';
 import { CardHeader, Table } from 'reactstrap';
+import ErrorCard from '../ErrorCard';
+import { ErrorBoundary } from './ErrorBoundary';
+import { widgetOnError } from './widgetCatchError';
 
 const initFromCache = (
   init: ChampionsLeagueScoreboardI
@@ -23,7 +26,7 @@ const initFromCache = (
   }
 };
 
-const Soccer = () => {
+const SoccerSchedule = () => {
   useEffect(() => {
     getChampionsLeagueData().then(data =>
       scheduleDispatch({ type: 'SET_NEW', newState: data })

--- a/src/components/Soccer.tsx
+++ b/src/components/Soccer.tsx
@@ -9,6 +9,7 @@ import { CardHeader, Table } from 'reactstrap';
 import ErrorCard from '../ErrorCard';
 import { ErrorBoundary } from './ErrorBoundary';
 import { widgetOnError } from './widgetCatchError';
+import { useThrowForErrorBoundary } from '../hooks/useErrorBoundary';
 
 const initFromCache = (
   init: ChampionsLeagueScoreboardI
@@ -27,11 +28,13 @@ const initFromCache = (
 };
 
 const SoccerSchedule = () => {
+  const [throwFcError] = useThrowForErrorBoundary();
+
   useEffect(() => {
-    getChampionsLeagueData().then(data =>
-      scheduleDispatch({ type: 'SET_NEW', newState: data })
-    );
-  }, []);
+    getChampionsLeagueData()
+      .then(data => scheduleDispatch({ type: 'SET_NEW', newState: data }))
+      .catch(e => throwFcError(e));
+  }, [throwFcError]);
 
   const [schedule, scheduleDispatch] = useReducer(
     createScheduleReducer<ChampionsLeagueScoreboardI>('SOCCER_DATA_v1'),
@@ -64,4 +67,12 @@ const SoccerSchedule = () => {
   );
 };
 
+const Soccer = () => (
+  <ErrorBoundary
+    onError={widgetOnError('Soccer', 'SOCCER_DATA_v1')}
+    message={<ErrorCard name="Soccer" />}
+  >
+    <SoccerSchedule />
+  </ErrorBoundary>
+);
 export default Soccer;

--- a/src/components/widgetCatchError.ts
+++ b/src/components/widgetCatchError.ts
@@ -1,0 +1,11 @@
+import { ErrorInfo } from 'react';
+
+export const widgetOnError = (name: string, localStorageKey: string) => (
+  error: Error,
+  errorInfo: ErrorInfo
+) => {
+  console.error(`ERROR BOUNDRY - ${name}`);
+  console.error(error, errorInfo);
+
+  localStorage.removeItem(localStorageKey);
+};

--- a/src/hooks/useErrorBoundary.tsx
+++ b/src/hooks/useErrorBoundary.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Iteration one
+ *
+ * Want to be able to throw Errors in async functions that are caught
+ * by React ErrorBoundary.
+ */
+export function useThrowForErrorBoundary() {
+  const [error, setError] = useState<Error | undefined>();
+
+  useEffect(() => {
+    if (error) {
+      throw error;
+    }
+  }, [error]);
+
+  return [setError];
+}


### PR DESCRIPTION
Place NFL, NBA, Soccer in ErrorBoundary's. 

Add hook that will rethrow errors so that ErrorBoundary can catch and display error message.

![image](https://user-images.githubusercontent.com/2523386/93724592-49635b80-fb5d-11ea-9a82-d52adcd7adf7.png)
