### PR TITLE
Mobile widget view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import NFL from './components/NFL';
 import NHL from './components/NHL';
 import MLB from './components/MLB';
 import NoInternet from './components/NoInternet';
+import { ResponsiveComponent } from './components/ResponsiveComponent';
+import { MobileView } from './MobileView';
 
 function App() {
   const [widgetsVisible, dispatch] = useReducer(
@@ -42,20 +44,27 @@ function App() {
 
   return (
     <div className="App">
-      <ControlBar toggles={toggles} toggle={toggleWidget} />
+      <ResponsiveComponent
+        sm={<ControlBar toggles={toggles} toggle={toggleWidget} />}
+      />
 
       <div className="container-fluid">
         <Message />
         <NoInternet />
 
-        <div className="card-columns">
-          {widgetsVisible.NFL && <NFL />}
-          {widgetsVisible.NBA && <NBA />}
-          {widgetsVisible.NHL && <NHL />}
-          {widgetsVisible.MLB && <MLB />}
-          {widgetsVisible.Soccer && <Soccer />}
-          {widgetsVisible.Links && <Links />}
-        </div>
+        <ResponsiveComponent
+          xs={<MobileView />}
+          sm={
+            <div className="py-4 card-columns">
+              {widgetsVisible.NFL && <NFL />}
+              {widgetsVisible.NBA && <NBA />}
+              {widgetsVisible.NHL && <NHL />}
+              {widgetsVisible.MLB && <MLB />}
+              {widgetsVisible.Soccer && <Soccer />}
+              {widgetsVisible.Links && <Links />}
+            </div>
+          }
+        />
       </div>
 
       <BackgroundInfo />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,12 +43,12 @@ function App() {
   });
 
   return (
-    <div className="App">
+    <div className="App d-flex flex-column align-self-stretch h-100">
       <ResponsiveComponent
         sm={<ControlBar toggles={toggles} toggle={toggleWidget} />}
       />
 
-      <div className="container-fluid">
+      <div className="container-fluid d-flex flex-column pb-0 h-100">
         <Message />
         <NoInternet />
 

--- a/src/MobileView.tsx
+++ b/src/MobileView.tsx
@@ -1,0 +1,72 @@
+import React, { useCallback, useState } from 'react';
+import { Button, Navbar } from 'reactstrap';
+import Links from './components/Links/Links';
+import MLB from './components/MLB';
+import NBA from './components/NBA';
+import NFL from './components/NFL';
+import NHL from './components/NHL';
+import Soccer from './components/Soccer';
+import { WidgetNames } from './WidgetVisibility';
+
+const LOCAL_STORAGE_KEY = 'WIDGETS_CONTROL_MOBILE_V1';
+
+export const MobileView = () => {
+  const widgets = ['NFL', 'NBA', 'NHL', 'MLB', 'Soccer', 'Links'] as const;
+
+  const [active, _setActive] = useState<WidgetNames>(() => {
+    const cachedName = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+    if (widgets.includes(cachedName as any)) return cachedName as WidgetNames;
+
+    return 'NFL';
+  });
+
+  const setActive = useCallback((name: WidgetNames) => {
+    _setActive(name);
+
+    localStorage.setItem(LOCAL_STORAGE_KEY, name);
+  }, []);
+
+  const widgetsNameToComponent = {
+    NFL,
+    NBA,
+    NHL,
+    MLB,
+    Soccer,
+    Links
+  } as const;
+
+  const activeWidgetName = widgets.find(w => w === active);
+
+  const WidgetToRender = activeWidgetName
+    ? widgetsNameToComponent[activeWidgetName]
+    : () => <></>;
+
+  return (
+    <>
+      <Navbar
+        color="dark"
+        className="d-flex justify-content-start p-1 mb-3 rounded"
+        style={{ color: 'gray' }}
+      >
+        {widgets.map((w, i) => (
+          <React.Fragment key={w}>
+            <Button
+              style={{
+                color: activeWidgetName === w ? '#ff4081' : '#ebe0df',
+                textDecoration: 'none'
+              }}
+              color="link"
+              onClick={() => setActive(w)}
+            >
+              {w}
+            </Button>
+            {i !== widgets.length - 1 && ` | `}
+          </React.Fragment>
+        ))}
+      </Navbar>
+
+      <WidgetToRender />
+    </>
+  );
+};

--- a/src/MobileView.tsx
+++ b/src/MobileView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { Button, Navbar } from 'reactstrap';
+import { ExtensionInfo } from './components/ExtensionInfo';
 import Links from './components/Links/Links';
 import MLB from './components/MLB';
 import NBA from './components/NBA';
@@ -66,7 +67,17 @@ export const MobileView = () => {
         ))}
       </Navbar>
 
-      <WidgetToRender />
+      <div style={{ flex: 1 }} className="mb-3">
+        <WidgetToRender />
+      </div>
+
+      <Navbar
+        color="dark"
+        className="d-flex justify-content-start p-2 mb-3 rounded"
+        style={{ color: 'gray' }}
+      >
+        <ExtensionInfo />
+      </Navbar>
     </>
   );
 };

--- a/src/WidgetVisibility.tsx
+++ b/src/WidgetVisibility.tsx
@@ -6,6 +6,7 @@ interface WidgetVisibility {
   Soccer: boolean;
   Links: boolean;
 }
+// Attention: Also add new key to MobileView !!!
 export type WidgetNames = keyof WidgetVisibility;
 
 type WidgetVisibilityAction = { type: 'toggle'; name: keyof WidgetVisibility };

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -33,7 +33,9 @@ export const ControlBar = ({ toggles, toggle }: ControlBarProps) => {
         />
       ))}
 
-      <ExtensionInfo />
+      <div className="ml-auto text-muted d-none d-lg-block">
+        <ExtensionInfo />
+      </div>
     </Navbar>
   );
 };

--- a/src/components/ExtensionInfo.tsx
+++ b/src/components/ExtensionInfo.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const Separator = () => <>&nbsp; &middot; &nbsp;</>;
 
 export const ExtensionInfo = () => (
-  <div className="ml-auto text-muted d-none d-lg-block">
+  <>
     Sports New Tab Page by OneiricArts
     <Separator />
     {/* @ts-ignore */}
@@ -15,5 +15,5 @@ export const ExtensionInfo = () => (
       </>
     )}
     <a href="https://forms.gle/iSkqzc53vC5zD7PX8">Feedback</a>
-  </div>
+  </>
 );

--- a/src/components/ResponsiveComponent.tsx
+++ b/src/components/ResponsiveComponent.tsx
@@ -1,0 +1,75 @@
+import React, { FC, ReactNode, useEffect, useState } from 'react';
+
+/**
+ * Render react component by breakpoints.
+ *
+ * Will render a component for specified screen size or above
+ *  - unless there is a component specified at a higher screen size
+ *
+ * Inspired by Bootstrap breakpoints, and using save values.
+ */
+
+type ScreenSizes = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+interface ResponsiveComponentProps {
+  xs?: ReactNode;
+  sm?: ReactNode;
+  md?: ReactNode;
+  lg?: ReactNode;
+  xl?: ReactNode;
+}
+
+const mqls = {
+  // xs is default
+  sm: window.matchMedia('(min-width: 576px)'),
+  md: window.matchMedia('(min-width: 768px)'),
+  lg: window.matchMedia('(min-width: 992px)'),
+  xl: window.matchMedia('(min-width: 1200px)')
+};
+
+const matchMqls = (): ScreenSizes => {
+  if (mqls.xl.matches) return 'xl';
+  if (mqls.lg.matches) return 'lg';
+  if (mqls.md.matches) return 'md';
+  if (mqls.sm.matches) return 'sm';
+
+  return 'xs';
+};
+
+export const ResponsiveComponent: FC<ResponsiveComponentProps> = props => {
+  const [screenSize, setScreenSize] = useState<ScreenSizes>(matchMqls());
+
+  useEffect(() => {
+    const setScreenSizeCallback = () => setScreenSize(matchMqls());
+
+    Object.values(mqls).forEach(mql =>
+      mql.addEventListener('change', setScreenSizeCallback)
+    );
+
+    return () => {
+      Object.values(mqls).forEach(mql =>
+        mql.removeEventListener('change', setScreenSizeCallback)
+      );
+    };
+  }, []);
+
+  let component: ReactNode;
+
+  const setXs = () => (component = props.xs);
+  const setSm = () => (props.sm ? (component = props.sm) : setXs());
+  const setMd = () => (props.md ? (component = props.md) : setSm());
+  const setLg = () => (props.lg ? (component = props.lg) : setMd());
+  const setXl = () => (props.xl ? (component = props.xl) : setLg());
+
+  const sizeToFunc = {
+    xs: setXs,
+    sm: setSm,
+    md: setMd,
+    lg: setLg,
+    xl: setXl
+  } as const;
+
+  sizeToFunc[screenSize]();
+
+  return <>{component}</>;
+};


### PR DESCRIPTION
In movile (xs) view:
* Shows a new switcher
* Shows the selected widget, defaults to NFL if no local cache
* Stores selected widget in separate local cache than desktop (so when expanded, the "on" widgets do not change)
* Shows extension info at bottom of screen

Has a bug in safari where extension info is not at the bottom of the screen, leaving as TODO in this PR


![image](https://user-images.githubusercontent.com/2523386/94508567-0e010680-01c7-11eb-9330-ba0b8f45cd79.png)
