### PR TITLE
NBA: Fix start time and Trail Blazers nickname

### DIFF
--- a/src/SportsDataAccessors/nba/getNBAData.ts
+++ b/src/SportsDataAccessors/nba/getNBAData.ts
@@ -82,7 +82,10 @@ const labelData: LabelDataI = (data, standings) => {
     let status: GameStatus;
 
     // pregame
-    if (!d.isGameActivated && d.period.current === 0) {
+    if (
+      (!d.isGameActivated && d.period.current === 0) ||
+      (d.period.current <= 1 && d.clock === '')
+    ) {
       status = { type: 'UTC_TIME', value: utcTime } as const;
     }
 

--- a/src/SportsDataAccessors/nba/teamInfo.ts
+++ b/src/SportsDataAccessors/nba/teamInfo.ts
@@ -45,7 +45,7 @@ export const teamCodeInfo = {
   PHX: { id: 1610612756, nickname: 'Suns', longName: 'Phoenix Suns' },
   POR: {
     id: 1610612757,
-    nickname: 'Blazers',
+    nickname: 'Trail Blazers',
     longName: 'Portland Trail Blazers'
   },
   SAC: { id: 1610612758, nickname: 'Kings', longName: 'Sacramento Kings' },


### PR DESCRIPTION
OLD: would show 1Q as the status before tip off
Now: show the start time until tip off


Change Trail Blazers nickname to one API returns in Standings