### PR TITLE
Loader utils - support a minimum wait time to show loading ui

### DIFF
--- a/src/components/GameTable.tsx
+++ b/src/components/GameTable.tsx
@@ -177,9 +177,11 @@ const TableHeader = ({
   <thead>
     <tr>
       <th /* status */>
-        <Loader isLoading={isLoading} minimum={1200}>
-          <Spinner size="sm" color="primary" type="grow" />
-        </Loader>
+        <Loader
+          isLoading={isLoading}
+          minimum={1200}
+          spinner={<Spinner size="sm" color="primary" type="grow" />}
+        />
       </th>
       <th>away</th>
       <th>@home</th>

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,62 +1,86 @@
-import { FC, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { FC, ReactNode, useEffect, useRef, useState } from 'react';
 
-type UseLoaderParams = { isLoading: boolean; minimum?: number };
+type UseLoaderParams = { isLoading: boolean; wait?: number; minimum?: number };
 
-const useLoader = ({ isLoading, minimum = 0 }: UseLoaderParams): boolean => {
+const useLoader = (props: UseLoaderParams): boolean => {
+  const { isLoading, minimum = 0, wait = 0 } = props;
+
   const [startedOn, setStartedOn] = useState(
     isLoading ? Date.now() : undefined
   );
 
-  const timer = useRef<number>();
-
-  const turnOff = useCallback(
-    (start: number) => {
-      const elapsedTime = Date.now() - start;
-      const remainder = minimum - elapsedTime;
-
-      if (remainder > 0) {
-        timer.current = window.setTimeout(() => {
-          setStartedOn(undefined);
-        }, remainder);
-      } else {
-        setStartedOn(undefined);
-      }
-    },
-    [minimum]
-  );
+  const offTimer = useRef<number>();
+  const onTimer = useRef<number>();
 
   useEffect(() => {
+    const turnOn = (wait: number) => {
+      if (onTimer.current) return;
+
+      onTimer.current = window.setTimeout(() => {
+        setStartedOn(Date.now());
+        onTimer.current = undefined;
+      }, wait);
+    };
+
+    const turnOff = (timer: number) => {
+      if (offTimer.current) return;
+
+      offTimer.current = window.setTimeout(() => {
+        setStartedOn(undefined);
+        offTimer.current = undefined;
+      }, timer);
+    };
+
     setStartedOn(s => {
-      // note: startedOn is set from Date.now() ... will never be 0
       const isOn = s !== undefined;
       const isOff = !isOn;
 
-      if (isOn && isLoading === true) {
-        // if turning off in progress -- clear
-        if (timer.current) window.clearTimeout(timer.current);
+      if (isOn && isLoading === true && offTimer.current) {
+        window.clearTimeout(offTimer.current); // clear any timers to turn off
+        offTimer.current = undefined;
 
         // keeps the initial startedOn value if called multiple times
       }
 
+      if (isOff && isLoading === false && onTimer.current) {
+        window.clearTimeout(onTimer.current); // clear any timers to turn on
+        onTimer.current = undefined;
+      }
+
       // start timer to turn off
       if (isOn && isLoading === false) {
-        turnOff(s);
+        const elapsedTime = Date.now() - s;
+        const remainder = minimum - elapsedTime;
+
+        if (remainder > 0) turnOff(remainder);
+        else return undefined;
       }
 
       // turn on
-      if (isOff && isLoading === true) return Date.now();
+      if (isOff && isLoading === true) {
+        if (wait > 0) turnOn(wait);
+        else return Date.now();
+      }
 
-      // ignore: isOff && isLoading === false
       return s;
     });
-  }, [isLoading, turnOff]);
+  }, [isLoading, wait, minimum]);
 
+  // note: startedOn is set from Date.now() ... will never be 0
   return !!startedOn;
 };
 
-type LoaderProps = UseLoaderParams & { children: ReactNode };
+type LoaderProps = UseLoaderParams & {
+  children?: ReactNode;
+  spinner: ReactNode;
+};
 
-export const Loader: FC<LoaderProps> = ({ children, ...useLoaderProps }) => {
+export const Loader: FC<LoaderProps> = ({
+  children,
+  spinner,
+  ...useLoaderProps
+}) => {
   const showLoading = useLoader(useLoaderProps);
-  return <>{showLoading && children}</>;
+
+  return <>{showLoading ? spinner : children}</>;
 };

--- a/src/components/NBAEspn.tsx
+++ b/src/components/NBAEspn.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useState } from 'react';
-import { Button } from 'reactstrap';
+import { Button, Spinner } from 'reactstrap';
 import ErrorCard from '../ErrorCard';
 import { useThrowForErrorBoundary } from '../hooks/useErrorBoundary';
 import useVisibilityHandlers from '../hooks/useVisibilityHandlers';
@@ -15,6 +15,7 @@ import { ChangeDate } from './NBA';
 import { NBAFavTeams } from './FavTeams';
 import { StandingsEspn } from './NBAStandingsEspn';
 import { widgetOnError } from './widgetCatchError';
+import { Loader } from './Loader';
 
 const initFromCache = (init: Schedule): Schedule => {
   try {
@@ -119,7 +120,7 @@ const NBASchedule = () => {
               </Button>
 
               <Button
-                style={{ marginLeft: '5px' }}
+                style={{ marginLeft: '5px', width: '74px' }}
                 outline
                 size="sm"
                 color="primary"
@@ -128,7 +129,14 @@ const NBASchedule = () => {
                 }}
                 disabled={!standings}
               >
-                Standings
+                <Loader
+                  isLoading={isLoading}
+                  wait={200}
+                  minimum={1200}
+                  spinner={<Spinner size="sm" color="primary" type="grow" />}
+                >
+                  Standings
+                </Loader>
               </Button>
             </div>
           </div>


### PR DESCRIPTION
Supports a minimum time to show the spinner/loading indicator. 

e.g. if a request is going to take < 100ms, we may not want to have the visual jitter of showing a spinner